### PR TITLE
ViewにModelから取得したデータを渡す際、デフォルトで特殊文字をエスケープするよう修正

### DIFF
--- a/module/View.php
+++ b/module/View.php
@@ -84,11 +84,19 @@ Class View{
 		require('../views/'.$this->page->getTemplate().'.view.php');
 	}
 
-	// Modelから渡されたデータの取得
-	private function getData(string $property) :string{
+	/**
+	 * Modelから渡されたデータを取得する
+	 *
+	 * @param string $property
+	 * @param integer $no_escape （デフォルト:特殊文字をエスケープする 1:エスケープしない）
+	 * @return string
+	 */
+	private function getData(string $property, int $no_escape=0) :string{
 		$data = $this->page->getData();
 		if(isset($data[$property])){
-			return (string) $data[$property];
+			$data = (string) $data[$property];
+			if($no_escape){ return $data; }
+			return htmlspecialchars($data, ENT_QUOTES);
 		}
 		return '';
 	}


### PR DESCRIPTION
セキュリティ対策の為、Modelで処理した内容をViewに書き出す関数getData()を通した時、デフォルトで特殊文字をエスケープするようにしました。

これによって、Modelで整形したhtmlのタグやJavascriptなどがエスケープされ、現在意図されている動作ではなくなります。
回避策として、getData()の第二引数に1を代入することで特殊文字をエスケープさせることができます。
ただし、例外を除いて特殊文字のエスケープを回避すべきではありません。

この変更をMergeする場合、影響範囲の修正が必要になります。
議論とテストを重ねたうえで更新しましょう。